### PR TITLE
First edition of proposal for dns trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT or Apache-2.0"
 [dependencies]
 nb = "0.1"
 no-std-net = "0.3.0"
+heapless = "^0.5"

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,5 +1,5 @@
+use heapless::{consts, String};
 use no_std_net::IpAddr;
-use heapless::{String, consts};
 
 /// This is the host address type to be returned by `gethostbyname`.
 ///
@@ -7,10 +7,12 @@ use heapless::{String, consts};
 /// will look for `AAAA` records
 #[derive(Clone, Debug, PartialEq)]
 pub enum AddrType {
-    /// Result is `A` record
-    IPv4,
-    /// Result is `AAAA` record
-    IPv6
+	/// Result is `A` record
+	IPv4,
+	/// Result is `AAAA` record
+	IPv6,
+	/// Result is either a `A` record, or a `AAAA` record
+	Either,
 }
 
 /// This trait is an extension trait for [`TcpStack`] and [`UdpStack`] for dns
@@ -24,18 +26,18 @@ pub enum AddrType {
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
 pub trait Dns {
-    /// The type returned when we have an error
-    type Error: core::fmt::Debug;
+	/// The type returned when we have an error
+	type Error: core::fmt::Debug;
 
-    /// Resolve the first ip address of a host, given its hostname and a desired
-    /// address record type to look for
-    fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
+	/// Resolve the first ip address of a host, given its hostname and a desired
+	/// address record type to look for
+	fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
 
-    /// Resolve the hostname of a host, given its ip address
-    ///
-    /// **Note**: A fully qualified domain name (FQDN), has a maximum length of
-    /// 255 bytes [`rfc1035`]
-    ///
-    /// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-    fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+	/// Resolve the hostname of a host, given its ip address
+	///
+	/// **Note**: A fully qualified domain name (FQDN), has a maximum length of
+	/// 255 bytes [`rfc1035`]
+	///
+	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
+	fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,41 @@
+use no_std_net::IpAddr;
+use heapless::{String, consts};
+
+/// This is the host address type to be returned by `gethostbyname`.
+///
+/// An IPv4 address type always looks for `A` records, while IPv6 address type
+/// will look for `AAAA` records
+#[derive(Clone, Debug, PartialEq)]
+pub enum AddrType {
+    /// Result is `A` record
+    IPv4,
+    /// Result is `AAAA` record
+    IPv6
+}
+
+/// This trait is an extension trait for [`TcpStack`] and [`UdpStack`] for dns
+/// resolutions. It does not handle every DNS record type, but is meant as an
+/// embedded alternative to [`ToSocketAddrs`], and is as such meant to resolve
+/// an ip address from a hostname, or a hostname from an ip address. This means
+/// that it only deals in host address records `A` (IPv4) and `AAAA` (IPv6).
+///
+/// [`TcpStack`]: trait.TcpStack.html
+/// [`UdpStack`]: trait.UdpStack.html
+/// [`ToSocketAddrs`]:
+/// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
+pub trait Dns {
+    /// The type returned when we have an error
+    type Error: core::fmt::Debug;
+
+    /// Resolve the first ip address of a host, given its hostname and a desired
+    /// address record type to look for
+    fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
+
+    /// Resolve the hostname of a host, given its ip address
+    ///
+    /// **Note**: A fully qualified domain name (FQDN), has a maximum length of
+    /// 255 bytes [`rfc1035`]
+    ///
+    /// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
+    fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
+mod dns;
+pub use dns::{Dns, AddrType};
+
 pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 /// Whether a socket should block when a read/write can't be performed, or return early.


### PR DESCRIPTION
This PR provides a simple DNS trait, similar to that provided by both `lwip` and the `Berkeley sockets API`, consisting of a simple `gethostbyname` function that resolves a hostname to the first ip address given by `A` or `AAAA` DNS record, depending on the requested `addr_type`, and a `gethostbyaddr` to resolve the hostname given an ip address. The later function has the `addr_type` encoded in the given `IpAddr` input.

This is a proposal for a first edition. It will not cover the full DNS, but it is equivalent of both `lwip` and the `Berkeley sockets API`, as well as the functionality given by `std::net::ToSocketAddrs`

Fixes #8 