### PR TITLE
Added a SocketAddr struct to the return signature of Udp.receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-...
+### Changed
+- Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 
 ## [0.1.0] - 2020-08-26
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,16 +84,16 @@ pub trait UdpStack {
 
 	/// Read a datagram the remote host has sent to us.
 	///
-	/// Returns `Ok(n)`, which means a datagram of size `n` has been received
-	/// and it has been placed in `&buffer[0..n]`, or an error. If a packet has
-	/// not been received when called, then
+	/// Returns `Ok((n, remote))`, which means a datagram of size `n` has been
+	/// received from `remote` and been placed in `&buffer[0..n]`, or an error.
+	/// If a packet has not been received when called, then
 	/// [`nb::Error::WouldBlock`](https://docs.rs/nb/1.0.0/nb/enum.Error.html#variant.WouldBlock)
 	/// should be returned.
 	fn read(
 		&self,
 		socket: &mut Self::UdpSocket,
 		buffer: &mut [u8],
-	) -> nb::Result<usize, Self::Error>;
+	) -> nb::Result<(usize, SocketAddr), Self::Error>;
 
 	/// Close an existing UDP socket.
 	fn close(&self, socket: Self::UdpSocket) -> Result<(), Self::Error>;


### PR DESCRIPTION
With the current function signature, a program can receive a packet, but has no idea of where it came from.  This alter the interface to expose that information.