### PR TITLE
Made Dns method names more rusty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed the names of `UdpClient`/`TcpClient` to `UdpClientStack`/`TcpClientStack`
 - Changed the names of `UdpServer`/`TcpServer` to `UdpFullStack`/`TcpFullStack`
+- Changed the method names `Dns::gethostbyname`/`Dns::gethostbyaddr` to `Dns::get_host_by_name`/`Dns::get_host_by_address`
 
 ## [0.2.0] - 2020-12-02
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -31,7 +31,7 @@ pub trait Dns {
 
 	/// Resolve the first ip address of a host, given its hostname and a desired
 	/// address record type to look for
-	fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
+	fn get_host_by_name(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///
@@ -39,5 +39,5 @@ pub trait Dns {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+	fn get_host_by_address(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
 }


### PR DESCRIPTION
This is a minor nitpick, but I think it would be better to use idiomatic Rust names for things, than legacy C names.
And it would be a convenient time, because we are introducing breaking changes with #36 anyway.