### PR TITLE
Removed Internal Mutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed the names of `UdpClient`/`TcpClient` to `UdpClientStack`/`TcpClientStack`
 - Changed the names of `UdpServer`/`TcpServer` to `UdpFullStack`/`TcpFullStack`
 - Changed the method names `Dns::gethostbyname`/`Dns::gethostbyaddr` to `Dns::get_host_by_name`/`Dns::get_host_by_address`
+- Changed self references in all network stack methods to mutable, with the intent of handling sharing in a different layer (see [#43](https://github.com/rust-embedded-community/embedded-nal/issues/43)).
 
 ## [0.2.0] - 2020-12-02
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,25 +26,29 @@ pub trait TcpClientStack {
 	/// The socket must be connected before it can be used.
 	///
 	/// Returns `Ok(socket)` if the socket was successfully created.
-	fn socket(&self) -> Result<Self::TcpSocket, Self::Error>;
+	fn socket(&mut self) -> Result<Self::TcpSocket, Self::Error>;
 
 	/// Connect to the given remote host and port.
 	///
 	/// Returns `Ok` if the connection was successful. Otherwise, if the connection could not be
 	/// completed immediately, this function should return [`nb::Error::WouldBlock`].
 	fn connect(
-		&self,
+		&mut self,
 		socket: &mut Self::TcpSocket,
 		remote: SocketAddr,
 	) -> nb::Result<(), Self::Error>;
 
 	/// Check if this socket is connected
-	fn is_connected(&self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+	fn is_connected(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
 	/// Write to the stream.
 	///
 	/// Returns the number of bytes written (which may be less than `buffer.len()`) or an error.
-	fn send(&self, socket: &mut Self::TcpSocket, buffer: &[u8]) -> nb::Result<usize, Self::Error>;
+	fn send(
+		&mut self,
+		socket: &mut Self::TcpSocket,
+		buffer: &[u8],
+	) -> nb::Result<usize, Self::Error>;
 
 	/// Receive data from the stream.
 	///
@@ -53,13 +57,13 @@ pub trait TcpClientStack {
 	/// not been received when called, then [`nb::Error::WouldBlock`]
 	/// should be returned.
 	fn receive(
-		&self,
+		&mut self,
 		socket: &mut Self::TcpSocket,
 		buffer: &mut [u8],
 	) -> nb::Result<usize, Self::Error>;
 
 	/// Close an existing TCP socket.
-	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;
+	fn close(&mut self, socket: Self::TcpSocket) -> Result<(), Self::Error>;
 }
 
 /// This trait is implemented by TCP/IP stacks that expose TCP server functionality. TCP servers
@@ -70,20 +74,20 @@ pub trait TcpFullStack: TcpClientStack {
 	///
 	/// Returns `Ok` when a socket is successfully bound to the specified local port. Otherwise, an
 	/// `Err(e)` variant is returned.
-	fn bind(&self, socket: &mut Self::TcpSocket, local_port: u16) -> Result<(), Self::Error>;
+	fn bind(&mut self, socket: &mut Self::TcpSocket, local_port: u16) -> Result<(), Self::Error>;
 
 	/// Begin listening for connection requests on a previously-bound socket.
 	///
 	/// Returns `Ok` if the socket was successfully transitioned to the listening state. Otherwise,
 	/// an `Err(e)` variant is returned.
-	fn listen(&self, socket: &mut Self::TcpSocket) -> Result<(), Self::Error>;
+	fn listen(&mut self, socket: &mut Self::TcpSocket) -> Result<(), Self::Error>;
 
 	/// Accept an active connection request on a listening socket.
 	///
 	/// Returns `Ok(connection)` if a new connection was created. If no pending connections are
 	/// available, this function should return [`nb::Error::WouldBlock`].
 	fn accept(
-		&self,
+		&mut self,
 		socket: &mut Self::TcpSocket,
 	) -> nb::Result<(Self::TcpSocket, SocketAddr), Self::Error>;
 }
@@ -100,18 +104,22 @@ pub trait UdpClientStack {
 	type Error: core::fmt::Debug;
 
 	/// Allocate a socket for further use.
-	fn socket(&self) -> Result<Self::UdpSocket, Self::Error>;
+	fn socket(&mut self) -> Result<Self::UdpSocket, Self::Error>;
 
 	/// Connect a UDP socket with a peer using a dynamically selected port.
 	///
 	/// Selects a port number automatically and initializes for read/writing.
-	fn connect(&self, socket: &mut Self::UdpSocket, remote: SocketAddr) -> Result<(), Self::Error>;
+	fn connect(
+		&mut self,
+		socket: &mut Self::UdpSocket,
+		remote: SocketAddr,
+	) -> Result<(), Self::Error>;
 
 	/// Send a datagram to the remote host.
 	///
 	/// The remote host used is either the one specified in `UdpStack::connect`
 	/// or the last one used in `UdpServerStack::write_to`.
-	fn send(&self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;
+	fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error>;
 
 	/// Read a datagram the remote host has sent to us.
 	///
@@ -120,24 +128,24 @@ pub trait UdpClientStack {
 	/// If a packet has not been received when called, then [`nb::Error::WouldBlock`]
 	/// should be returned.
 	fn receive(
-		&self,
+		&mut self,
 		socket: &mut Self::UdpSocket,
 		buffer: &mut [u8],
 	) -> nb::Result<(usize, SocketAddr), Self::Error>;
 
 	/// Close an existing UDP socket.
-	fn close(&self, socket: Self::UdpSocket) -> Result<(), Self::Error>;
+	fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error>;
 }
 
 /// This trait is implemented by UDP/IP stacks.  It provides the ability to
 /// listen for packets on a specified port and send replies.
 pub trait UdpFullStack: UdpClientStack {
 	/// Bind a UDP socket with a specified port
-	fn bind(&self, socket: &mut Self::UdpSocket, local_port: u16) -> Result<(), Self::Error>;
+	fn bind(&mut self, socket: &mut Self::UdpSocket, local_port: u16) -> Result<(), Self::Error>;
 
 	/// Send a packet to a remote host/port.
 	fn send_to(
-		&self,
+		&mut self,
 		socket: &mut Self::UdpSocket,
 		remote: SocketAddr,
 		buffer: &[u8],


### PR DESCRIPTION
Removed requirement on internal mutability by using mutable self references in methods.

See #39 for details.  Should not be merged unless that alternate approach to sharing is approved.

/resolves #39 