### PR TITLE
pub use heapless

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ mod dns;
 mod stack;
 
 pub use nb;
+// Needed by embedded-nal trait implementers who build get_host_by_address results, or by trait
+// users who pass the results on.
+pub use heapless;
 pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 pub use dns::{AddrType, Dns};


### PR DESCRIPTION
This is needed by embedded-nal trait implementers who build get_host_by_address results, or by trait users who pass the results on.

Closes: https://github.com/rust-embedded-community/embedded-nal/issues/17

Without this, they have to pull in a heapless dependency on their own and pray it resolves to the same version (aided by careful adjustment of the version they depend on). With this, they can just operate on the type embedded-nal uses.