### PR TITLE
Change DNS trait to return nb, and bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.36.0
+          - rust: 1.46.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed [`Dns`](./src/dns.rs) methods to return `nb::Result<..>` to allow non-blocking implementations.
 - Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
 - Bump dependency version of `no-std-net` to `v0.5`.
+- Bump MSRV to 1.46.0 to get `const-fn` for `no-std-net`.
 
 
 ## [0.3.0] - 2021-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-* None
+- Changed [`Dns`](./src/dns.rs) methods to return `nb::Result<..>` to allow non-blocking implementations.
+- Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
+- Bump dependency version of `no-std-net` to `v0.5`.
+
 
 ## [0.3.0] - 2021-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+* None
+
+## [0.4.0] - 2021-03-05
+
+### Changed
 - Changed [`Dns`](./src/dns.rs) methods to return `nb::Result<..>` to allow non-blocking implementations.
 - Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
 - Bump dependency version of `no-std-net` to `v0.5`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ categories = ["embedded", "hardware-support", "no-std", "network-programming"]
 
 [dependencies]
 nb = "1"
-no-std-net = "0.4"
-heapless = "^0.5"
+no-std-net = "0.5"
+heapless = "^0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-nal"
-version = "0.3.0" # remember to update html_root_url
+version = "0.4.0" # remember to update html_root_url
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "Mathias Koch <mk@blackbird.online>",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These issues / PRs will be labeled as `proposal`s in the issue tracker.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.36.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.46.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -31,7 +31,11 @@ pub trait Dns {
 
 	/// Resolve the first ip address of a host, given its hostname and a desired
 	/// address record type to look for
-	fn get_host_by_name(&self, hostname: &str, addr_type: AddrType) -> Result<IpAddr, Self::Error>;
+	fn get_host_by_name(
+		&self,
+		hostname: &str,
+		addr_type: AddrType,
+	) -> nb::Result<IpAddr, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///
@@ -39,5 +43,5 @@ pub trait Dns {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+	fn get_host_by_address(&self, addr: IpAddr) -> nb::Result<String<consts::U256>, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # embedded-nal - A Network Abstraction Layer for Embedded Systems
 
-#![doc(html_root_url = "https://docs.rs/embedded-nal/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/embedded-nal/0.4.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]


### PR DESCRIPTION
- Changed `Dns` methods to return `nb::Result<..>` to allow non-blocking implementations.
- Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
- Bump dependency version of `no-std-net` to `v0.5`.

Fixes #35 