### PR TITLE
Change self references in dns stack methods to mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-* None
+- Changed self references in dns stack methods to mutable, to follow the network stack implementations.
 
 ## [0.5.0] - 2021-05-20
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -32,7 +32,7 @@ pub trait Dns {
 	/// Resolve the first ip address of a host, given its hostname and a desired
 	/// address record type to look for
 	fn get_host_by_name(
-		&self,
+		&mut self,
 		hostname: &str,
 		addr_type: AddrType,
 	) -> nb::Result<IpAddr, Self::Error>;
@@ -43,5 +43,5 @@ pub trait Dns {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&self, addr: IpAddr) -> nb::Result<String<256>, Self::Error>;
+	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error>;
 }


### PR DESCRIPTION
I think the DNS trait was overlooked, when the change to mutable self references happened for the network stacks?

This changes self references in dns stack methods to mutable, to follow the network stack implementations.