### PR TITLE
Retrieve multiple IP addresses when resolving a hostname.

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -28,14 +28,16 @@ pub enum AddrType {
 pub trait Dns {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
+	/// An iterator of IP addresses.
+	type IpAddrIter: Iterator<Item = IpAddr>;
 
-	/// Resolve the first ip address of a host, given its hostname and a desired
-	/// address record type to look for
+	/// Resolves the IP addresses associated with a host, given its hostname and a desired
+	/// address record type to look for.
 	fn get_host_by_name(
 		&mut self,
 		hostname: &str,
 		addr_type: AddrType,
-	) -> nb::Result<IpAddr, Self::Error>;
+	) -> nb::Result<Self::IpAddrIter, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,3 +1,5 @@
+use core::mem::MaybeUninit;
+
 use heapless::String;
 use no_std_net::IpAddr;
 
@@ -28,16 +30,15 @@ pub enum AddrType {
 pub trait Dns {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
-	/// An iterator of IP addresses.
-	type IpAddrIter: Iterator<Item = IpAddr>;
 
 	/// Resolves the IP addresses associated with a host, given its hostname and a desired
 	/// address record type to look for.
-	fn get_host_by_name(
+	fn get_hosts_by_name<'a>(
 		&mut self,
 		hostname: &str,
 		addr_type: AddrType,
-	) -> nb::Result<Self::IpAddrIter, Self::Error>;
+		outputs: &'a mut [MaybeUninit<IpAddr>],
+	) -> Result<&'a [IpAddr], Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///
@@ -45,5 +46,5 @@ pub trait Dns {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error>;
+	fn get_host_by_address(&mut self, addr: IpAddr) -> Result<String<256>, Self::Error>;
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -27,18 +27,19 @@ pub enum AddrType {
 /// [`UdpStack`]: crate::trait@UdpStack
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
-pub trait Dns {
+pub trait Dns<'a> {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
+	/// The iterator returned by `get_hosts_by_name`.
+	type IpAddrIter: Iterator<Item = IpAddr> + 'a;
 
 	/// Resolves the IP addresses associated with a host, given its hostname and a desired
 	/// address record type to look for.
-	fn get_hosts_by_name<'a>(
-		&mut self,
-		hostname: &str,
+	fn get_hosts_by_name(
+		&'a mut self,
+		hostname: &'a str,
 		addr_type: AddrType,
-		outputs: &'a mut [MaybeUninit<IpAddr>],
-	) -> Result<&'a [IpAddr], Self::Error>;
+	) -> Result<Self::IpAddrIter, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,6 +1,3 @@
-use core::mem::MaybeUninit;
-
-use heapless::String;
 use no_std_net::IpAddr;
 
 /// This is the host address type to be returned by `gethostbyname`.
@@ -27,19 +24,17 @@ pub enum AddrType {
 /// [`UdpStack`]: crate::trait@UdpStack
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
-pub trait Dns<'a> {
+pub trait Dns {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
-	/// The iterator returned by `get_hosts_by_name`.
-	type IpAddrIter: Iterator<Item = IpAddr> + 'a;
 
 	/// Resolves the IP addresses associated with a host, given its hostname and a desired
 	/// address record type to look for.
-	fn get_hosts_by_name(
-		&'a mut self,
-		hostname: &'a str,
+	fn get_hosts_by_name<const UP_TO: usize>(
+		&mut self,
+		hostname: &str,
 		addr_type: AddrType,
-	) -> Result<Self::IpAddrIter, Self::Error>;
+	) -> Result<heapless::Vec<IpAddr, UP_TO>, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///
@@ -47,5 +42,5 @@ pub trait Dns<'a> {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&mut self, addr: IpAddr) -> Result<String<256>, Self::Error>;
+	fn get_host_by_address(&mut self, addr: IpAddr) -> Result<heapless::String<256>, Self::Error>;
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -27,14 +27,16 @@ pub enum AddrType {
 pub trait Dns {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
+	/// Iterator through the IP addresses associated with a hostname.
+	type AddrIter: Iterator<Item = IpAddr>;
 
 	/// Resolves the IP addresses associated with a host, given its hostname and a desired
 	/// address record type to look for.
-	fn get_hosts_by_name<const UP_TO: usize>(
+	fn get_hosts_by_name(
 		&mut self,
 		hostname: &str,
 		addr_type: AddrType,
-	) -> Result<heapless::Vec<IpAddr, UP_TO>, Self::Error>;
+	) -> Result<Self::AddrIter, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///


### PR DESCRIPTION
This PR changes the `Dns::get_host_by_name` function to `Dns::get_hosts_by_name` and makes it return an iterator.