### PR TITLE
Add blanket impls for mutable references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-* None
+* Add blanket impls of all the traits for mutable references.
 
 ## [0.6.0] - 2021-05-25
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -45,3 +45,19 @@ pub trait Dns {
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
 	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error>;
 }
+
+impl<T: Dns> Dns for &mut T {
+	type Error = T::Error;
+
+	fn get_host_by_name(
+		&mut self,
+		hostname: &str,
+		addr_type: AddrType,
+	) -> nb::Result<IpAddr, Self::Error> {
+		T::get_host_by_name(self, hostname, addr_type)
+	}
+
+	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error> {
+		T::get_host_by_address(self, addr)
+	}
+}

--- a/src/stack/tcp.rs
+++ b/src/stack/tcp.rs
@@ -80,3 +80,45 @@ pub trait TcpFullStack: TcpClientStack {
 		socket: &mut Self::TcpSocket,
 	) -> nb::Result<(Self::TcpSocket, SocketAddr), Self::Error>;
 }
+
+impl<T: TcpClientStack> TcpClientStack for &mut T {
+	type Error = T::Error;
+
+	type TcpSocket = T::TcpSocket;
+
+	fn socket(&mut self) -> Result<Self::TcpSocket, Self::Error> {
+		T::socket(self)
+	}
+
+	fn connect(
+		&mut self,
+		socket: &mut Self::TcpSocket,
+		remote: SocketAddr,
+	) -> nb::Result<(), Self::Error> {
+		T::connect(self, socket, remote)
+	}
+
+	fn is_connected(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
+		T::is_connected(self, socket)
+	}
+
+	fn send(
+		&mut self,
+		socket: &mut Self::TcpSocket,
+		buffer: &[u8],
+	) -> nb::Result<usize, Self::Error> {
+		T::send(self, socket, buffer)
+	}
+
+	fn receive(
+		&mut self,
+		socket: &mut Self::TcpSocket,
+		buffer: &mut [u8],
+	) -> nb::Result<usize, Self::Error> {
+		T::receive(self, socket, buffer)
+	}
+
+	fn close(&mut self, socket: Self::TcpSocket) -> Result<(), Self::Error> {
+		T::close(self, socket)
+	}
+}

--- a/src/stack/udp.rs
+++ b/src/stack/udp.rs
@@ -59,3 +59,52 @@ pub trait UdpFullStack: UdpClientStack {
 		buffer: &[u8],
 	) -> nb::Result<(), Self::Error>;
 }
+
+impl<T: UdpClientStack> UdpClientStack for &mut T {
+	type Error = T::Error;
+
+	type UdpSocket = T::UdpSocket;
+
+	fn socket(&mut self) -> Result<Self::UdpSocket, Self::Error> {
+		T::socket(self)
+	}
+
+	fn connect(
+		&mut self,
+		socket: &mut Self::UdpSocket,
+		remote: SocketAddr,
+	) -> Result<(), Self::Error> {
+		T::connect(self, socket, remote)
+	}
+
+	fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error> {
+		T::send(self, socket, buffer)
+	}
+
+	fn receive(
+		&mut self,
+		socket: &mut Self::UdpSocket,
+		buffer: &mut [u8],
+	) -> nb::Result<(usize, SocketAddr), Self::Error> {
+		T::receive(self, socket, buffer)
+	}
+
+	fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error> {
+		T::close(self, socket)
+	}
+}
+
+impl<T: UdpFullStack> UdpFullStack for &mut T {
+	fn bind(&mut self, socket: &mut Self::UdpSocket, local_port: u16) -> Result<(), Self::Error> {
+		T::bind(self, socket, local_port)
+	}
+
+	fn send_to(
+		&mut self,
+		socket: &mut Self::UdpSocket,
+		remote: SocketAddr,
+		buffer: &[u8],
+	) -> nb::Result<(), Self::Error> {
+		T::send_to(self, socket, remote, buffer)
+	}
+}


### PR DESCRIPTION
I recently ran into an issue where i had a closure of signature `F: FnOnce(&mut dyn TcpClientStack<TcpSocket = Handle, Error = Error>)`, which requires an impl of the `embedded-nal` traits for mutable references as `impl<T: TcpClientStack> TcpClientStack for &mut T`, in order to be used in functions like `fn foo<T: TcpClientStack>(network: &mut T) { ... }`.

This PR adds those blanket implementations for all the traits in this repo.

This is also in line with the agreed upon way in `embedded-hal`: https://github.com/rust-embedded/embedded-hal/pull/310