### PR TITLE
Fix bad category name

### DIFF
--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.1.0] - 2022-05-04
+
+Initial release to crates.io.

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/rust-embedded-community/embedded-nal"
 documentation = "https://docs.rs/embedded-nal-async"
 readme = "README.md"
 keywords = ["network"]
-categories = ["embedded", "hardware-support", "no-std", "network-programming", "async"]
+categories = ["embedded", "hardware-support", "no-std", "network-programming", "asynchronous"]
 
 [dependencies]
 no-std-net = "0.5"


### PR DESCRIPTION
The 'async' category passed the --dry-run check, but when I attempted to publish it failed.