### PR TITLE
TcpClient trait for creating shared TCP/IP stack

### DIFF
--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+TcpClient trait for creating shared async TCP/IP stack implementations.
+
 ## [0.1.0] - 2022-05-04
 
 Initial release to crates.io.

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -18,3 +18,4 @@ categories = ["embedded", "hardware-support", "no-std", "network-programming", "
 no-std-net = "0.5"
 heapless = "^0.7"
 embedded-nal = { version = "0.6.0", path = "../" }
+embedded-io = { version = "0.3.0", default-features = false, features = ["async"] }

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -14,4 +14,4 @@ pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, Socke
 
 pub use dns::Dns;
 pub use embedded_nal::AddrType;
-pub use stack::{TcpClientStack, TcpFullStack, UdpClientStack, UdpFullStack};
+pub use stack::{TcpClientStack, TcpConnect, TcpFullStack, UdpClientStack, UdpFullStack};

--- a/embedded-nal-async/src/stack/mod.rs
+++ b/embedded-nal-async/src/stack/mod.rs
@@ -1,5 +1,5 @@
 mod tcp;
 mod udp;
 
-pub use tcp::{TcpClientStack, TcpFullStack};
+pub use tcp::{TcpClientStack, TcpConnect, TcpFullStack};
 pub use udp::{UdpClientStack, UdpFullStack};

--- a/embedded-nal-async/src/stack/tcp.rs
+++ b/embedded-nal-async/src/stack/tcp.rs
@@ -170,3 +170,39 @@ impl<T: TcpClientStack> TcpClientStack for &mut T {
 		T::close(self, socket)
 	}
 }
+
+/// This trait is implemented by TCP/IP stacks. The trait allows the underlying driver to
+/// construct multiple connections that implement the I/O traits from embedded-io.
+///
+/// The associated connection type should close the connection when dropped.
+pub trait TcpConnect {
+	/// Error type returned on connect failure.
+	type Error: embedded_io::Error;
+
+	/// Type holding state of a TCP connection. Should close the connection when dropped.
+	type Connection<'m>: embedded_io::asynch::Read<Error = Self::Error>
+		+ embedded_io::asynch::Write<Error = Self::Error>
+	where
+		Self: 'm;
+	/// Future returned by `connect` function.
+	type ConnectFuture<'m>: Future<Output = Result<Self::Connection<'m>, Self::Error>> + 'm
+	where
+		Self: 'm;
+
+	/// Connect to the given remote host and port.
+	///
+	/// Returns `Ok` if the connection was successful.
+	fn connect<'m>(&'m self, remote: SocketAddr) -> Self::ConnectFuture<'m>;
+}
+
+impl<T: TcpConnect> TcpConnect for &T {
+	type Error = T::Error;
+
+	type Connection<'m> = T::Connection<'m> where Self: 'm;
+
+	type ConnectFuture<'m> = T::ConnectFuture<'m> where Self: 'm;
+
+	fn connect<'m>(&'m self, remote: SocketAddr) -> Self::ConnectFuture<'m> {
+		T::connect(self, remote)
+	}
+}


### PR DESCRIPTION
New set of traits using embedded-io that allows creating shared TCP stack implementations using async.