### PR TITLE
Traits for asynchronous UDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/embedded-nal-async/target
 **/*.rs.bk
 Cargo.lock

--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add traits for UDP
+
 ## [0.3.0] - 2022-11-25
 
 - Bump `embedded-io` dependency to `0.4`

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -15,3 +15,4 @@ pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, Socke
 pub use dns::Dns;
 pub use embedded_nal::AddrType;
 pub use stack::TcpConnect;
+pub use stack::{ConnectedUdp, UdpStack, UnconnectedUdp};

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 #![feature(generic_associated_types)]
+#![feature(async_fn_in_trait)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 

--- a/embedded-nal-async/src/stack/mod.rs
+++ b/embedded-nal-async/src/stack/mod.rs
@@ -1,3 +1,5 @@
 mod tcp;
+mod udp;
 
 pub use tcp::TcpConnect;
+pub use udp::{BoundUdp, ConnectedUdp, UdpStack, UnboundUdp};

--- a/embedded-nal-async/src/stack/mod.rs
+++ b/embedded-nal-async/src/stack/mod.rs
@@ -2,4 +2,4 @@ mod tcp;
 mod udp;
 
 pub use tcp::TcpConnect;
-pub use udp::{BoundUdp, ConnectedUdp, UdpStack, UnboundUdp};
+pub use udp::{ConnectedUdp, UdpStack, UnconnectedUdp};

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -130,21 +130,10 @@ pub trait UdpStack {
 	///
 	/// The local address is chosen automatically.
 	///
-	/// While asynchronous traits implemented through GAT can not have provided default methods,
-	/// implementers are encouraged to use the hidden `.connect_default()` method if all they would
-	/// do is delegating to [`.connect_from`] with a suitable unspecified local address.
-	async fn connect(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
-
-	/// Create a socket that has a fixed remote address.
-	///
-	/// The local address is given explicitly, but may be partially unspecified; it is fixed by the
-	/// network stack at connection time. The full local address is returned along with the
-	/// connected socket, primarily for debugging purposes.
-	async fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
-
-	/// Helper that implements [`connect()`] using [`connect_from()`].
-	#[doc(hidden)]
-	async fn connect_default(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error> {
+    /// There is a provided implementation that implements this from the maximally unspecified
+    /// local address and [`.connect_from()`], but may be provided more efficiently by
+    /// implementers.
+	async fn connect(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error> {
 		use no_std_net::{Ipv4Addr, Ipv6Addr, SocketAddr::*, SocketAddrV4, SocketAddrV6};
 
 		let local = match remote {
@@ -152,7 +141,14 @@ pub trait UdpStack {
 			V6(_) => V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)),
 		};
 		self.connect_from(local, remote).await
-	}
+    }
+
+	/// Create a socket that has a fixed remote address.
+	///
+	/// The local address is given explicitly, but may be partially unspecified; it is fixed by the
+	/// network stack at connection time. The full local address is returned along with the
+	/// connected socket, primarily for debugging purposes.
+	async fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
 
 	/// Create a socket that has a fixed local address.
 	///

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -107,7 +107,10 @@ pub trait UnconnectedUdp {
 	///
 	/// The local and remote address are given, in that order, in the result along with the number
 	/// of bytes.
-	async fn receive_into(& mut self, buffer: & mut [u8]) -> Result<(usize, SocketAddr, SocketAddr), Self::Error>;
+	async fn receive_into(
+		&mut self,
+		buffer: &mut [u8],
+	) -> Result<(usize, SocketAddr, SocketAddr), Self::Error>;
 }
 
 /// This trait is implemented by UDP/IP stacks. The trait allows the underlying driver to
@@ -130,10 +133,13 @@ pub trait UdpStack {
 	///
 	/// The local address is chosen automatically.
 	///
-    /// There is a provided implementation that implements this from the maximally unspecified
-    /// local address and [`.connect_from()`], but may be provided more efficiently by
-    /// implementers.
-	async fn connect(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error> {
+	/// There is a provided implementation that implements this from the maximally unspecified
+	/// local address and [`.connect_from()`], but may be provided more efficiently by
+	/// implementers.
+	async fn connect(
+		&self,
+		remote: SocketAddr,
+	) -> Result<(SocketAddr, Self::Connected), Self::Error> {
 		use no_std_net::{Ipv4Addr, Ipv6Addr, SocketAddr::*, SocketAddrV4, SocketAddrV6};
 
 		let local = match remote {
@@ -141,14 +147,18 @@ pub trait UdpStack {
 			V6(_) => V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)),
 		};
 		self.connect_from(local, remote).await
-    }
+	}
 
 	/// Create a socket that has a fixed remote address.
 	///
 	/// The local address is given explicitly, but may be partially unspecified; it is fixed by the
 	/// network stack at connection time. The full local address is returned along with the
 	/// connected socket, primarily for debugging purposes.
-	async fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
+	async fn connect_from(
+		&self,
+		local: SocketAddr,
+		remote: SocketAddr,
+	) -> Result<(SocketAddr, Self::Connected), Self::Error>;
 
 	/// Create a socket that has a fixed local address.
 	///
@@ -158,7 +168,10 @@ pub trait UdpStack {
 	///
 	/// The full local address is returned along with the bound socket; it may then be passed on to
 	/// other protocols for advertising purposes.
-	async fn bind_single(&self, local: SocketAddr) -> Result<(SocketAddr, Self::UniquelyBound), Self::Error>;
+	async fn bind_single(
+		&self,
+		local: SocketAddr,
+	) -> Result<(SocketAddr, Self::UniquelyBound), Self::Error>;
 
 	/// Create a socket that has no single fixed local address.
 	///
@@ -183,5 +196,4 @@ pub trait UdpStack {
 	///   binding to `[::]:0`, that is, picking some available port but then still leaving the
 	///   interface and IP address unspecified.
 	async fn bind_multiple(&self, local: SocketAddr) -> Result<Self::MultiplyBound, Self::Error>;
-
 }

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -31,7 +31,7 @@ pub trait ConnectedUdp {
 	type Error: embedded_io::Error;
 
 	/// Send the provided data to the connected peer
-	fn send(&mut self, data: &[u8]) -> Self::SendFuture<'_>;
+	fn send<'a>(&'a mut self, data: &'a [u8]) -> Self::SendFuture<'a>;
 	/// Return type of the [`.send()`] method
 	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
 	where
@@ -48,7 +48,7 @@ pub trait ConnectedUdp {
 	/// This deviates from the sync/nb equivalent trait in that it describes the overflow behavior
 	/// (a possibility not considered there). The name deviates from the original `receive()` to
 	/// make room for a version that is more zero-copy friendly.
-	fn receive_into(&mut self, buffer: &mut [u8]) -> Self::ReceiveIntoFuture<'_>;
+	fn receive_into<'a>(&'a mut self, buffer: &'a mut [u8]) -> Self::ReceiveIntoFuture<'a>;
 	/// Return type of the [`.receive_into()`] method
 	type ReceiveIntoFuture<'a>: Future<Output = Result<usize, Self::Error>>
 	where
@@ -100,7 +100,12 @@ pub trait UnconnectedUdp {
 	/// receive time; these should be equal. This allows implementations of the trait to use a
 	/// single kind of socket for both sockets bound to a single and sockets bound to multiple
 	/// addresses.
-	fn send(&mut self, local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Self::SendFuture<'_>;
+	fn send<'a>(
+		&'a mut self,
+		local: SocketAddr,
+		remote: SocketAddr,
+		data: &'a [u8],
+	) -> Self::SendFuture<'a>;
 	/// Return type of the [`.send()`] method
 	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
 	where
@@ -114,7 +119,7 @@ pub trait UnconnectedUdp {
 	///
 	/// The local and remote address are given, in that order, in the result along with the number
 	/// of bytes.
-	fn receive_into(&mut self, buffer: &mut [u8]) -> Self::ReceiveIntoFuture<'_>;
+	fn receive_into<'a>(&'a mut self, buffer: &'a mut [u8]) -> Self::ReceiveIntoFuture<'a>;
 	/// Return type of the [`.receive_into()`] method
 	type ReceiveIntoFuture<'a>: Future<
 		Output = Result<(usize, SocketAddr, SocketAddr), Self::Error>,

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -14,7 +14,6 @@
 //!   Implementing `UniquelyBound` and `MultiplyBound` with the same type is expected to be a
 //!   common choice.
 
-use core::future::Future;
 use no_std_net::SocketAddr;
 
 /// This trait is implemented by UDP sockets.
@@ -32,11 +31,7 @@ pub trait ConnectedUdp {
 	type Error: embedded_io::Error;
 
 	/// Send the provided data to the connected peer
-	fn send<'a>(&'a mut self, data: &'a [u8]) -> Self::SendFuture<'a>;
-	/// Return type of the [`.send()`] method
-	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
-	where
-		Self: 'a;
+	async fn send(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 
 	/// Receive a datagram into the provided buffer.
 	///
@@ -49,11 +44,7 @@ pub trait ConnectedUdp {
 	/// This deviates from the sync/nb equivalent trait in that it describes the overflow behavior
 	/// (a possibility not considered there). The name deviates from the original `receive()` to
 	/// make room for a version that is more zero-copy friendly.
-	fn receive_into<'a>(&'a mut self, buffer: &'a mut [u8]) -> Self::ReceiveIntoFuture<'a>;
-	/// Return type of the [`.receive_into()`] method
-	type ReceiveIntoFuture<'a>: Future<Output = Result<usize, Self::Error>>
-	where
-		Self: 'a;
+	async fn receive_into(&mut self, buffer: &mut [u8]) -> Result<usize, Self::Error>;
 
 	// WIP to allow zero-copy operation
 	// The plain receive is simple and can be provided -- implementations that don't populate
@@ -61,8 +52,8 @@ pub trait ConnectedUdp {
 	// on the socket still being exclusively owned. receive_oned is harder as providing it requires
 	// alloc.
 	//
-	// fn receive(&mut self, buffer: &mut [u8]) -> impl Future<Output = Result<impl AsRef<u8> + '_, Self::Error>>;
-	// fn receive_owned(&mut self) -> impl Future<Output = Result<impl AsRef<u8> + 'static, Self::Error>>;
+	// async fn receive(&mut self, buffer: &mut [u8]) -> utput = Result<impl AsRef<u8> + '_, Self::Error>;
+	// async fn receive_owned(&mut self) -> Result<impl AsRef<u8> + 'static, Self::Error>;
 }
 
 /// This trait is implemented by UDP sockets.
@@ -101,16 +92,12 @@ pub trait UnconnectedUdp {
 	/// receive time; these should be equal. This allows implementations of the trait to use a
 	/// single kind of socket for both sockets bound to a single and sockets bound to multiple
 	/// addresses.
-	fn send<'a>(
-		&'a mut self,
+	async fn send(
+		&mut self,
 		local: SocketAddr,
 		remote: SocketAddr,
-		data: &'a [u8],
-	) -> Self::SendFuture<'a>;
-	/// Return type of the [`.send()`] method
-	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
-	where
-		Self: 'a;
+		data: &[u8],
+	) -> Result<(), Self::Error>;
 
 	/// Receive a datagram into the provided buffer.
 	///
@@ -120,12 +107,7 @@ pub trait UnconnectedUdp {
 	///
 	/// The local and remote address are given, in that order, in the result along with the number
 	/// of bytes.
-	fn receive_into<'a>(&'a mut self, buffer: &'a mut [u8]) -> Self::ReceiveIntoFuture<'a>;
-	/// Return type of the [`.receive_into()`] method
-	type ReceiveIntoFuture<'a>: Future<
-		Output = Result<(usize, SocketAddr, SocketAddr), Self::Error>,
-	> where
-		Self: 'a;
+	async fn receive_into(& mut self, buffer: & mut [u8]) -> Result<(usize, SocketAddr, SocketAddr), Self::Error>;
 }
 
 /// This trait is implemented by UDP/IP stacks. The trait allows the underlying driver to
@@ -138,17 +120,11 @@ pub trait UdpStack {
 	type Error: embedded_io::Error;
 
 	/// Eventual socket return type of the [`.connect()`] method
-	type Connected<'m>: ConnectedUdp
-	where
-		Self: 'm;
+	type Connected: ConnectedUdp;
 	/// Eventual socket return type of the [`.bind_single()`] method
-	type UniquelyBound<'m>: UnconnectedUdp
-	where
-		Self: 'm;
+	type UniquelyBound: UnconnectedUdp;
 	/// Eventual return type of the [`.bind_multiple()`] method
-	type MultiplyBound<'m>: UnconnectedUdp
-	where
-		Self: 'm;
+	type MultiplyBound: UnconnectedUdp;
 
 	/// Create a socket that has a fixed remote address.
 	///
@@ -157,34 +133,25 @@ pub trait UdpStack {
 	/// While asynchronous traits implemented through GAT can not have provided default methods,
 	/// implementers are encouraged to use the hidden `.connect_default()` method if all they would
 	/// do is delegating to [`.connect_from`] with a suitable unspecified local address.
-	fn connect(&self, remote: SocketAddr) -> Self::ConnectFuture<'_>;
-	/// Future return type of the [`.connect()`] method
-	type ConnectFuture<'a>: Future<Output = Result<(SocketAddr, Self::Connected<'a>), Self::Error>>
-	where
-		Self: 'a;
+	async fn connect(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
 
 	/// Create a socket that has a fixed remote address.
 	///
 	/// The local address is given explicitly, but may be partially unspecified; it is fixed by the
 	/// network stack at connection time. The full local address is returned along with the
 	/// connected socket, primarily for debugging purposes.
-	fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Self::ConnectFromFuture<'_>;
-	/// Future return type of the [`.connect_from()`] method
-	type ConnectFromFuture<'a>: Future<
-		Output = Result<(SocketAddr, Self::Connected<'a>), Self::Error>,
-	> where
-		Self: 'a;
+	async fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error>;
 
 	/// Helper that implements [`connect()`] using [`connect_from()`].
 	#[doc(hidden)]
-	fn connect_default(&self, remote: SocketAddr) -> Self::ConnectFromFuture<'_> {
+	async fn connect_default(&self, remote: SocketAddr) -> Result<(SocketAddr, Self::Connected), Self::Error> {
 		use no_std_net::{Ipv4Addr, Ipv6Addr, SocketAddr::*, SocketAddrV4, SocketAddrV6};
 
 		let local = match remote {
 			V4(_) => V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
 			V6(_) => V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)),
 		};
-		self.connect_from(local, remote)
+		self.connect_from(local, remote).await
 	}
 
 	/// Create a socket that has a fixed local address.
@@ -195,12 +162,7 @@ pub trait UdpStack {
 	///
 	/// The full local address is returned along with the bound socket; it may then be passed on to
 	/// other protocols for advertising purposes.
-	fn bind_single(&self, local: SocketAddr) -> Self::BindSingleFuture<'_>;
-	/// Future return type of the [`.bind_single()`] method
-	type BindSingleFuture<'a>: Future<
-		Output = Result<(SocketAddr, Self::UniquelyBound<'a>), Self::Error>,
-	> where
-		Self: 'a;
+	async fn bind_single(&self, local: SocketAddr) -> Result<(SocketAddr, Self::UniquelyBound), Self::Error>;
 
 	/// Create a socket that has no single fixed local address.
 	///
@@ -224,9 +186,6 @@ pub trait UdpStack {
 	/// * There is currently no hybrid binding that allows emulating what POSIX systems do when
 	///   binding to `[::]:0`, that is, picking some available port but then still leaving the
 	///   interface and IP address unspecified.
-	fn bind_multiple(&self, local: SocketAddr) -> Self::BindMultipleFuture<'_>;
-	/// Future return type of the [`.bind_multiple()`] method
-	type BindMultipleFuture<'a>: Future<Output = Result<Self::MultiplyBound<'a>, Self::Error>>
-	where
-		Self: 'a;
+	async fn bind_multiple(&self, local: SocketAddr) -> Result<Self::MultiplyBound, Self::Error>;
+
 }

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -123,11 +123,11 @@ pub trait UdpStack {
 	type Error: embedded_io::Error;
 
 	/// Eventual socket return type of the [`.connect()`] method
-	type Connected: ConnectedUdp;
+	type Connected: ConnectedUdp<Error = Self::Error>;
 	/// Eventual socket return type of the [`.bind_single()`] method
-	type UniquelyBound: UnconnectedUdp;
+	type UniquelyBound: UnconnectedUdp<Error = Self::Error>;
 	/// Eventual return type of the [`.bind_multiple()`] method
-	type MultiplyBound: UnconnectedUdp;
+	type MultiplyBound: UnconnectedUdp<Error = Self::Error>;
 
 	/// Create a socket that has a fixed remote address.
 	///

--- a/embedded-nal-async/src/stack/udp.rs
+++ b/embedded-nal-async/src/stack/udp.rs
@@ -1,0 +1,225 @@
+use core::future::Future;
+use no_std_net::SocketAddr;
+
+/// This trait is implemented by UDP sockets.
+///
+/// The socket it represents is both bound (has a local IP address, port and interface) and
+/// connected (has a remote IP address and port).
+///
+/// The term "connected" here refers to the semantics of POSIX datagram sockets, through which datagrams
+/// are sent and received without having a remote address per call. It does not imply any process
+/// of establishing a connection (which is absent in UDP). While there is typically no POSIX
+/// `bind()` call in the creation of such sockets, these are implicitly bound to a suitable local
+/// address at connect time.
+pub trait ConnectedUdp {
+	type Error: embedded_io::Error;
+
+	/// Send the provided data to the connected peer
+	fn send(&mut self, data: &[u8]) -> Self::SendFuture<'_>;
+	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
+	where
+		Self: 'a;
+
+	/// Receive a datagram into the provided buffer.
+	///
+	/// If the received datagram exceeds the buffer's length, it is received regardless, and the
+	/// remaining bytes are discarded. The full datagram size is still indicated in the result,
+	/// allowing the recipient to detect that truncation.
+	///
+	/// ## Compatibility note
+	///
+	/// This deviates from the sync/nb equivalent trait in that it describes the overflow behavior
+	/// (a possibility not considered there). The name deviates from the original `receive()` to
+	/// make room for a version that is more zero-copy friendly.
+	fn receive_into(&mut self, buffer: &mut [u8]) -> Self::ReceiveIntoFuture<'_>;
+	type ReceiveIntoFuture<'a>: Future<Output = Result<usize, Self::Error>>
+	where
+		Self: 'a;
+
+	// WIP to allow zero-copy operation
+	// The plain receive is simple and can be provided -- implementations that don't populate
+	// receive calls from scatter-gather can just return a slice of the raw data instead, and rely
+	// on the socket still being exclusively owned. receive_oned is harder as providing it requires
+	// alloc.
+	//
+	// fn receive(&mut self, buffer: &mut [u8]) -> impl Future<Output = Result<impl AsRef<u8> + '_, Self::Error>>;
+	// fn receive_owned(&mut self) -> impl Future<Output = Result<impl AsRef<u8> + 'static, Self::Error>>;
+}
+
+/// This trait is implemented by UDP sockets.
+///
+/// The socket it represents is both bound (has a local IP address, port and interface) but not
+/// connected; its peer IP address is explicit in every call.
+///
+/// This is similar to a POSIX datagram socket that has been bound to a concrete address.
+pub trait BoundUdp {
+	type Error: embedded_io::Error;
+
+	/// Send the provided data to the connected peer
+	fn send_to(&mut self, remote: SocketAddr, data: &[u8]) -> Self::SendToFuture<'_>;
+	type SendToFuture<'a>: Future<Output = Result<(), Self::Error>>
+	where
+		Self: 'a;
+
+	/// Receive a datagram into the provided buffer.
+	///
+	/// If the received datagram exceeds the buffer's length, it is received regardless, and the
+	/// remaining bytes are discarded. The full datagram size is still indicated in the result,
+	/// allowing the recipient to detect that truncation.
+	///
+	/// The remote address is given in the result along with the number of bytes.
+	///
+	/// ## Compatibility note
+	///
+	/// This deviates from the sync/nb equivalent trait in that it describes the overflow behavior
+	/// (a possibility not considered there). The name deviates from the original `receive()` to
+	/// make room for a version that is more zero-copy friendly.
+	fn receive_from_into(&mut self, buffer: &mut [u8]) -> Self::ReceiveFromIntoFuture<'_>;
+	type ReceiveFromIntoFuture<'a>: Future<Output = Result<(usize, SocketAddr), Self::Error>>
+	where
+		Self: 'a;
+}
+
+/// This trait is implemented by UDP sockets.
+///
+/// The socket it represents is neither bound (has no single local IP address, port and interface)
+/// nor connected (has no remote IP address and port). Both are explicitly given in every call.
+///
+/// There may be constraints placed on an unbound socket at creation time that limit the range of
+/// local addresses (further than the natural limitation of only using addresses assigned to the
+/// host).
+///
+/// A typical example of this kind of socket is a POSIX datagram socket that has been bound to
+/// "any" address (`[::]` or `0.0.0.0`) but to a particular port.
+pub trait UnboundUdp {
+	type Error: embedded_io::Error;
+
+	/// Send the provided data to the connected peer
+	///
+	/// ## Sending initial messages
+	///
+	/// The local address can be left unspecified by leaving any of its component zero -- that
+	/// gives the "any" address (`[::]` / `0.0.0.0`), the uncspecified port (0) or the unspecified
+	/// zone identifier (0). Unless the operating system provides facilities exceeding this crate's traits for
+	/// enumerating local interfaces and addresses, this is the only way to initiate outbound
+	/// traffic.
+	///
+	/// ## Responding to messages
+	///
+	/// Users who have previously received data from a peer and want to respond have a choice of
+	/// sending from the address to which the original datagram was addressed, or from an unbound
+	/// address. Both are valid choices in some situations, and the right choice depends on the
+	/// protocol used.
+	fn send(&mut self, local: SocketAddr, remote: SocketAddr, data: &[u8]) -> Self::SendFuture<'_>;
+	type SendFuture<'a>: Future<Output = Result<(), Self::Error>>
+	where
+		Self: 'a;
+
+	/// Receive a datagram into the provided buffer.
+	///
+	/// If the received datagram exceeds the buffer's length, it is received regardless, and the
+	/// remaining bytes are discarded. The full datagram size is still indicated in the result,
+	/// allowing the recipient to detect that truncation.
+	///
+	/// The local and remote address are given, in that order, in the result along with the number
+	/// of bytes.
+	fn receive(&mut self, buffer: &mut [u8]) -> Self::ReceiveFuture<'_>;
+	type ReceiveFuture<'a>: Future<Output = Result<(usize, SocketAddr, SocketAddr), Self::Error>>
+	where
+		Self: 'a;
+}
+
+/// This trait is implemented by UDP/IP stacks. The trait allows the underlying driver to
+/// construct multiple connections that implement the I/O traits from embedded-io.
+///
+/// Note that stacks with exotic connection creation methods may still not implement this, yet have
+/// objects that implement [`ConnectedUdp`] or similar.
+pub trait UdpStack {
+	/// Error type returned on socket creation failure.
+	type Error: embedded_io::Error;
+
+	type Connected<'m>: ConnectedUdp
+	where
+		Self: 'm;
+	type Bound<'m>: BoundUdp
+	where
+		Self: 'm;
+	type Unbound<'m>: UnboundUdp
+	where
+		Self: 'm;
+
+	/// Create a socket that has a fixed remote address.
+	///
+	/// The local address is chosen automatically.
+	///
+	/// While asynchronous traits implemented through GAT can not have provided default methods,
+	/// implementers are encouraged to use the hidden `.connect_default()` method if all they would
+	/// do is delegating to [`connect_from`] with a suitable unspecified local address.
+	fn connect(&self, remote: SocketAddr) -> Self::ConnectFuture<'_>;
+	type ConnectFuture<'a>: Future<Output = Result<(SocketAddr, Self::Connected<'a>), Self::Error>>
+	where
+		Self: 'a;
+
+	/// Create a socket that has a fixed remote address.
+	///
+	/// The local address is given explicitly, but may be partially unspecified; it is fixed by the
+	/// network stack at connection time. The full local address is returned along with the
+	/// connected socket, primarily for debugging purposes.
+	fn connect_from(&self, local: SocketAddr, remote: SocketAddr) -> Self::ConnectFromFuture<'_>;
+	type ConnectFromFuture<'a>: Future<
+		Output = Result<(SocketAddr, Self::Connected<'a>), Self::Error>,
+	> where
+		Self: 'a;
+
+	/// Helper that implements [`connect()`] using [`connect_from()`].
+	#[doc(hidden)]
+	fn connect_default(&self, remote: SocketAddr) -> Self::ConnectFromFuture<'_> {
+		use no_std_net::{Ipv4Addr, Ipv6Addr, SocketAddr::*, SocketAddrV4, SocketAddrV6};
+
+		let local = match remote {
+			V4(_) => V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
+			V6(_) => V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0)),
+		};
+		self.connect_from(local, remote)
+	}
+
+	/// Create a socket that has a fixed local address.
+	///
+	/// Note that the giving an unspecified address here is *not* the same as a POSIX `bind()` --
+	/// if the underlying stack supports multiple local addresses, it will pick *one* of the
+	/// applicable addresses, rather than binding to all of them.
+	///
+	/// The full local address is returned along with the bound socket; it may then be passed on to
+	/// other protocols for advertising purposes.
+	fn bind_single(&self, local: SocketAddr) -> Self::BindSingleFuture<'_>;
+	type BindSingleFuture<'a>: Future<Output = Result<(SocketAddr, Self::Bound<'a>), Self::Error>>
+	where
+		Self: 'a;
+
+	/// Create a socket that has no single fixed local address.
+	///
+	/// The IP address part of the local address is typically left unspecified, and the port is
+	/// given. There are use cases for other constellations, and this interface does not rule out
+	/// that they can be used, but they are rare (e.g. using the same IP address on different
+	/// network interfaces, and listening to datagrams arriving at any of them) or not well
+	/// supported by operating systems (e.g., binding to all ports at the same is not possible on
+	/// POSIX systems, where giving port 0 to a bind makes the OS pick *some* suitable port).
+	///
+	/// Caveats:
+	///
+	/// * There is currently no way to pass in a local address that has an unspecified address
+	///   family (which would effectively create a single socket that servers both IPv4 and IPv6);
+	///   it is not specified whether stacks that use V6MAPPED IPv4 addresses could simply used
+	///   that mechanism.
+	///
+	/// * It is currently not specified whether this mechanism can be used to join multicast
+	///   groups.
+	///
+	/// * There is currently no hybrid binding that allows emulating what POSIX systems do when
+	///   binding to `[::]:0`, that is, picking some available port but then still leaving the
+	///   interface and IP address unspecified.
+	fn bind_multiple(&self, local: SocketAddr) -> Self::BindMultipleFuture<'_>;
+	type BindMultipleFuture<'a>: Future<Output = Result<Self::Unbound<'a>, Self::Error>>
+	where
+		Self: 'a;
+}


### PR DESCRIPTION
Closes: https://github.com/rust-embedded-community/embedded-nal/issues/71

---

This adds traits for UDP that were removed in #70, but built from scratch. These address, in one go:

* Their API is now socket oriented (no passing the stack to socket operations, which is essential for async as discussed in #69/#70).
* Type differentiation between connected, bound and unbound sockets (#63), following the pattern of TcpConnect established in #70. There are currently no plans to convert between those, as they might be completely different beasts on different platforms. (But maybe traits that allow an unbound or bound socket to `accept()` and spin off a bound one might be added later).
* Send and receive methods take local addresses precisely in the cases where that is sensible, addressing #40.
* Binding now takes any parts of the address, although not all OSes might support all patterns, addressing #41.

This is early WIP and only checked to the point where it compiles; no implementations or users have been written yet -- but I'd like to have it around early for discussion.