### PR TITLE
Bump no-std-net dependency to 0.6, MSRV to 1.53

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.51.0
+          - rust: 1.53.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 * Add blanket impls of all the traits for mutable references.
+- Bump dependency version of `no-std-net` to `v0.6`.
 
 ## [0.6.0] - 2021-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add blanket impls of all the traits for mutable references.
 - Bump dependency version of `no-std-net` to `v0.6`.
+- Bump MSRV to 1.53.0 due to `no-std-net`'s use of or-patterns.
 
 ## [0.6.0] - 2021-05-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ categories = ["embedded", "hardware-support", "no-std", "network-programming"]
 
 [dependencies]
 nb = "1"
-no-std-net = "0.5"
+no-std-net = "0.6"
 heapless = "^0.7"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These issues / PRs will be labeled as `proposal`s in the issue tracker.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.51.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.53.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["network"]
 categories = ["embedded", "hardware-support", "no-std", "network-programming", "asynchronous"]
 
 [dependencies]
-no-std-net = "0.5"
+no-std-net = "0.6"
 heapless = "^0.7"
 embedded-nal = { version = "0.6.0", path = "../" }
 embedded-io = { version = "0.3.0", default-features = false, features = ["async"] }


### PR DESCRIPTION
The no-std-net version currently used (0.5) failed to parse `SocketAddr` strings `"[fe80::1]%2"`, which works correctly in the 0.6 version.

Incrementing the version is this easy change (nothing inside current embedded-nal appears to depend on the precise version), but it is an API breaking change in the crates here because types are re-exported and their API changed. (For example, `Ipv6Addr::unspecified()` became `Ipv6Addr::UNSPECIFIED`).  Given that these crates have not yet had non-breaking updates, that's probably not a big deal.