### PR TITLE
async: switch to async-fn-in-trait, release 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [nightly]
+        rust: [nightly-2022-11-22]
         TARGET: [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 
     steps:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-11-22
           override: true
           components: clippy
       - run: cargo clippy

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-11-22
           override: true
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2022-11-25
+
+- Bump `embedded-io` dependency to `0.4`
+- Switch all traits to use [`async_fn_in_trait`](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html) (AFIT). Requires `nightly-2022-11-22` or newer.
+
 ## [0.2.0] - 2022-08-03
 
 TcpClient trait for creating shared async TCP/IP stack implementations.

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -18,4 +18,4 @@ categories = ["embedded", "hardware-support", "no-std", "network-programming", "
 no-std-net = "0.6"
 heapless = "^0.7"
 embedded-nal = { version = "0.6.0", path = "../" }
-embedded-io = { version = "0.3.0", default-features = false, features = ["async"] }
+embedded-io = { version = "0.4.0", default-features = false, features = ["async"] }

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-nal-async"
-version = "0.2.0" # remember to update html_root_url
+version = "0.3.0"
 authors = [
     "Ulf Lilleengen <lulf@redhat.com>",
 ]

--- a/embedded-nal-async/src/dns.rs
+++ b/embedded-nal-async/src/dns.rs
@@ -1,4 +1,3 @@
-use core::future::Future;
 use embedded_nal::AddrType;
 use heapless::String;
 use no_std_net::IpAddr;
@@ -17,23 +16,13 @@ pub trait Dns {
 	/// The type returned when we have an error
 	type Error: core::fmt::Debug;
 
-	/// Future for get_host_by_name
-	type GetHostByNameFuture<'m>: Future<Output = Result<IpAddr, Self::Error>>
-	where
-		Self: 'm;
-
 	/// Resolve the first ip address of a host, given its hostname and a desired
 	/// address record type to look for
-	fn get_host_by_name<'m>(
-		&'m self,
-		host: &'m str,
+	async fn get_host_by_name<'m>(
+		&self,
+		host: &str,
 		addr_type: AddrType,
-	) -> Self::GetHostByNameFuture<'m>;
-
-	/// Future for get_host_by_address
-	type GetHostByAddressFuture<'m>: Future<Output = Result<String<256>, Self::Error>>
-	where
-		Self: 'm;
+	) -> Result<IpAddr, Self::Error>;
 
 	/// Resolve the hostname of a host, given its ip address
 	///
@@ -41,5 +30,5 @@ pub trait Dns {
 	/// 255 bytes [`rfc1035`]
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address<'m>(&'m self, addr: IpAddr) -> Self::GetHostByAddressFuture<'m>;
+	async fn get_host_by_address(&self, addr: IpAddr) -> Result<String<256>, Self::Error>;
 }

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -1,7 +1,8 @@
 //! # embedded-nal-async - An async Network Abstraction Layer for Embedded Systems
 
 #![no_std]
-#![feature(generic_associated_types)]
+#![feature(async_fn_in_trait, impl_trait_projections)]
+#![allow(incomplete_features)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 

--- a/embedded-nal-async/src/stack/tcp.rs
+++ b/embedded-nal-async/src/stack/tcp.rs
@@ -1,4 +1,3 @@
-use core::future::Future;
 use no_std_net::SocketAddr;
 
 /// This trait is implemented by TCP/IP stacks. The trait allows the underlying driver to
@@ -10,29 +9,29 @@ pub trait TcpConnect {
 	type Error: embedded_io::Error;
 
 	/// Type holding state of a TCP connection. Should close the connection when dropped.
-	type Connection<'m>: embedded_io::asynch::Read<Error = Self::Error>
+	type Connection<'a>: embedded_io::asynch::Read<Error = Self::Error>
 		+ embedded_io::asynch::Write<Error = Self::Error>
 	where
-		Self: 'm;
-	/// Future returned by `connect` function.
-	type ConnectFuture<'m>: Future<Output = Result<Self::Connection<'m>, Self::Error>> + 'm
-	where
-		Self: 'm;
+		Self: 'a;
 
 	/// Connect to the given remote host and port.
 	///
 	/// Returns `Ok` if the connection was successful.
-	fn connect<'m>(&'m self, remote: SocketAddr) -> Self::ConnectFuture<'m>;
+	async fn connect<'a>(&'a self, remote: SocketAddr) -> Result<Self::Connection<'a>, Self::Error>
+	// This bound is required due to an AFIT limitaton: https://github.com/rust-lang/rust/issues/104908
+	where
+		Self: 'a;
 }
 
 impl<T: TcpConnect> TcpConnect for &T {
 	type Error = T::Error;
 
-	type Connection<'m> = T::Connection<'m> where Self: 'm;
+	type Connection<'a> = T::Connection<'a> where Self: 'a;
 
-	type ConnectFuture<'m> = T::ConnectFuture<'m> where Self: 'm;
-
-	fn connect<'m>(&'m self, remote: SocketAddr) -> Self::ConnectFuture<'m> {
-		T::connect(self, remote)
+	async fn connect<'a>(&'a self, remote: SocketAddr) -> Result<Self::Connection<'a>, Self::Error>
+	where
+		Self: 'a,
+	{
+		T::connect(self, remote).await
 	}
 }


### PR DESCRIPTION
- Bump embedded-io to 0.4 (uses AFIT)
- Switch the traits to AFIT

This is a breaking change.