### PR TITLE
Prepare for 0.4.0 release

### DIFF
--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-01-27
+
 - Add traits for UDP
 
 ## [0.3.0] - 2022-11-25

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "embedded-nal-async"
-version = "0.3.0"
-authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-]
-edition = "2018"
+version = "0.4.0"
+edition = "2021"
 description = "An Async Network Abstraction Layer (NAL) for Embedded Systems"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-embedded-community/embedded-nal"


### PR DESCRIPTION
I'd like to release a 0.4.0 version with the UDP traits.