### PR TITLE
Remove html_root_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-nal"
-version = "0.6.0" # remember to update html_root_url
+version = "0.6.0"
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "Mathias Koch <mk@blackbird.online>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 //! # embedded-nal - A Network Abstraction Layer for Embedded Systems
-
-#![doc(html_root_url = "https://docs.rs/embedded-nal/0.6.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]


### PR DESCRIPTION
This is no longer recommended in the API guidelines: https://github.com/rust-lang/api-guidelines/pull/230