### PR TITLE
Adding new TCP socket APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump dependency version of `no-std-net` to `v0.6`.
 - Bump MSRV to 1.53.0 due to `no-std-net`'s use of or-patterns.
 - Added support for `core::net` with the `ip_in_core` feature.
+- [breaking] New APIs added to `TcpClientStack` to support more robust understanding of the TCP
+socket state
+    * New APIs include `is_open()`, `may_send()`, and `may_recv()`
 
 ## [0.6.0] - 2021-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump dependency version of `no-std-net` to `v0.6`.
 - Bump MSRV to 1.53.0 due to `no-std-net`'s use of or-patterns.
 - Added support for `core::net` with the `ip_in_core` feature.
-- [breaking] New APIs added to `TcpClientStack` to support more robust understanding of the TCP
-socket state
-    * New APIs include `is_open()`, `may_send()`, and `may_recv()`
+- [breaking] New TCP error enumerations added for identifying TCP-related connection errors
+- [breaking] Removed the `TcpClientStack::is_connected` API
 
 ## [0.6.0] - 2021-05-25
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,6 @@ pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, Socke
 
 pub use dns::{AddrType, Dns};
 pub use stack::{
-	SharableStack, SharedStack, TcpClientStack, TcpFullStack, UdpClientStack, UdpFullStack,
+	SharableStack, SharedStack, TcpClientStack, TcpError, TcpErrorKind, TcpFullStack,
+	UdpClientStack, UdpFullStack,
 };

--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -3,5 +3,5 @@ mod tcp;
 mod udp;
 
 pub use share::{SharableStack, SharedStack};
-pub use tcp::{TcpClientStack, TcpFullStack};
+pub use tcp::{TcpClientStack, TcpError, TcpErrorKind, TcpFullStack};
 pub use udp::{UdpClientStack, UdpFullStack};

--- a/src/stack/share.rs
+++ b/src/stack/share.rs
@@ -128,9 +128,6 @@ where
 	forward! {connect(socket: &mut Self::TcpSocket, address: SocketAddr) -> Result<(), nb::Error<<T as TcpClientStack>::Error>>}
 	forward! {send(socket: &mut Self::TcpSocket, data: &[u8]) -> Result<usize, nb::Error<<T as TcpClientStack>::Error>>}
 	forward! {receive(socket: &mut Self::TcpSocket, data: &mut [u8]) -> Result<usize, nb::Error<<T as TcpClientStack>::Error>>}
-	forward! {is_open(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
-	forward! {may_send(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
-	forward! {may_receive(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
 	forward! {close(socket: Self::TcpSocket) -> Result<(), Self::Error>}
 }
 

--- a/src/stack/share.rs
+++ b/src/stack/share.rs
@@ -128,7 +128,9 @@ where
 	forward! {connect(socket: &mut Self::TcpSocket, address: SocketAddr) -> Result<(), nb::Error<<T as TcpClientStack>::Error>>}
 	forward! {send(socket: &mut Self::TcpSocket, data: &[u8]) -> Result<usize, nb::Error<<T as TcpClientStack>::Error>>}
 	forward! {receive(socket: &mut Self::TcpSocket, data: &mut [u8]) -> Result<usize, nb::Error<<T as TcpClientStack>::Error>>}
-	forward! {is_connected(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
+	forward! {is_open(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
+	forward! {may_send(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
+	forward! {may_receive(socket: &Self::TcpSocket) -> Result<bool, Self::Error>}
 	forward! {close(socket: Self::TcpSocket) -> Result<(), Self::Error>}
 }
 

--- a/src/stack/tcp.rs
+++ b/src/stack/tcp.rs
@@ -4,7 +4,7 @@ use crate::SocketAddr;
 #[non_exhaustive]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum TcpErrorKind {
-	/// The peer has closed one or both directions and the connection is broken.
+	/// The socket has been closed in the direction in which the failing operation was attempted.
 	PipeClosed,
 
 	/// Some other error has occurred.

--- a/src/stack/tcp.rs
+++ b/src/stack/tcp.rs
@@ -28,20 +28,20 @@ pub trait TcpClientStack {
 	) -> nb::Result<(), Self::Error>;
 
 	/// Determine if a socket is opened.
-    ///
-    /// Returns `Ok(true)` if the TCP socket is actively ingressing and egressing packets. This
-    /// corresponds to any TCP state that is not `CLOSED` or `TIME-WAIT`.
+	///
+	/// Returns `Ok(true)` if the TCP socket is actively ingressing and egressing packets. This
+	/// corresponds to any TCP state that is not `CLOSED` or `TIME-WAIT`.
 	fn is_open(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
-    /// Check if the TCP socket can transmit data.
-    ///
-    /// Returns `Ok(true)` if the TCP transmit half is open and connected.
-    fn may_send(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+	/// Check if the TCP socket can transmit data.
+	///
+	/// Returns `Ok(true)` if the TCP transmit half is open and connected.
+	fn may_send(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
-    /// Check if the TCP socket can receive data.
-    ///
-    /// Returns `Ok(true)` if the TCP receive half is open and connected.
-    fn may_receive(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+	/// Check if the TCP socket can receive data.
+	///
+	/// Returns `Ok(true)` if the TCP receive half is open and connected.
+	fn may_receive(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
 	/// Write to the stream.
 	///

--- a/src/stack/tcp.rs
+++ b/src/stack/tcp.rs
@@ -111,8 +111,16 @@ impl<T: TcpClientStack> TcpClientStack for &mut T {
 		T::connect(self, socket, remote)
 	}
 
-	fn is_connected(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
-		T::is_connected(self, socket)
+	fn is_open(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
+		T::is_open(self, socket)
+	}
+
+	fn may_send(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
+		T::may_send(self, socket)
+	}
+
+	fn may_receive(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error> {
+		T::may_receive(self, socket)
 	}
 
 	fn send(

--- a/src/stack/tcp.rs
+++ b/src/stack/tcp.rs
@@ -27,8 +27,21 @@ pub trait TcpClientStack {
 		remote: SocketAddr,
 	) -> nb::Result<(), Self::Error>;
 
-	/// Check if this socket is connected
-	fn is_connected(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+	/// Determine if a socket is opened.
+    ///
+    /// Returns `Ok(true)` if the TCP socket is actively ingressing and egressing packets. This
+    /// corresponds to any TCP state that is not `CLOSED` or `TIME-WAIT`.
+	fn is_open(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+
+    /// Check if the TCP socket can transmit data.
+    ///
+    /// Returns `Ok(true)` if the TCP transmit half is open and connected.
+    fn may_send(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+
+    /// Check if the TCP socket can receive data.
+    ///
+    /// Returns `Ok(true)` if the TCP receive half is open and connected.
+    fn may_receive(&mut self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
 	/// Write to the stream.
 	///


### PR DESCRIPTION
Fixes #52 by exposing a more robust API for TCP sockets.

I recently [hit an issue with minimq](https://github.com/quartiq/minimq/issues/125) where the `is_connected()` interface was determined to be insufficiently expressive to properly managing the TCP socket state.
