### PR TITLE
Preparing for a 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.7.0] - 2023-06-21
 
 * Add blanket impls of all the traits for mutable references.
 - Bump dependency version of `no-std-net` to `v0.6`.
@@ -67,7 +67,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/rust-embedded-community/embedded-nal/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.7.0] - 2023-06-21
 
 * Add blanket impls of all the traits for mutable references.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-nal"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "Mathias Koch <mk@blackbird.online>",

--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Let `&T` for `T: Dns` implement `Dns`
+- Bumped to `embedded-nal` 0.7
 
 ## [0.4.0] - 2023-01-27
 

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -17,5 +17,5 @@ ip_in_core = []
 [dependencies]
 no-std-net = "0.6"
 heapless = "^0.7"
-embedded-nal = { version = "0.6.0", path = "../" }
+embedded-nal = { version = "0.7.0", path = "../" }
 embedded-io = { version = "0.4.0", default-features = false, features = ["async"] }


### PR DESCRIPTION
Releasing 0.7.0 of the `embedded-nal` to address some TCP soundness issues.

Fixes #84 

I'd also like to take a look at revamping the TCP API to be more like `embassy-net`, but I'm unsure if we should block the release of a new version on potential future work for now.

Thoughts @rust-embedded-community/embedded-nal ?