### PR TITLE
Switch to Edition 2021, bump MSRV.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [staging, trying, master]
   pull_request:
 
 name: Continuous integration
@@ -14,11 +14,12 @@ jobs:
         rust: [stable]
 
         # The default target we're compiling on and for
-        TARGET: [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
+        TARGET:
+          [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 
         include:
           # Test MSRV
-          - rust: 1.53.0
+          - rust: 1.60.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -42,7 +43,8 @@ jobs:
     strategy:
       matrix:
         rust: [nightly-2022-11-22]
-        TARGET: [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
+        TARGET:
+          [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Bump MSRV to 1.60.0 (required for Edition 2021)
+- Switch to Edition 2021
+
 ## [0.7.0] - 2023-06-21
 
-* Add blanket impls of all the traits for mutable references.
+- Add blanket impls of all the traits for mutable references.
 - Bump dependency version of `no-std-net` to `v0.6`.
 - Bump MSRV to 1.53.0 due to `no-std-net`'s use of or-patterns.
 - Added support for `core::net` with the `ip_in_core` feature.
@@ -30,18 +33,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0] - 2021-03-05
 
 ### Changed
+
 - Changed [`Dns`](./src/dns.rs) methods to return `nb::Result<..>` to allow non-blocking implementations.
 - Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
 - Bump dependency version of `no-std-net` to `v0.5`.
 - Bump MSRV to 1.46.0 to get `const-fn` for `no-std-net`.
 
-
 ## [0.3.0] - 2021-02-15
 
 ### Added
+
 - New optional struct [`SharedNal`](./src/stack/share.rs) that can share a single underlying implementation among several users within a thread.
 
 ### Changed
+
 - Changed the names of `UdpClient`/`TcpClient` to `UdpClientStack`/`TcpClientStack`
 - Changed the names of `UdpServer`/`TcpServer` to `UdpFullStack`/`TcpFullStack`
 - Changed the method names `Dns::gethostbyname`/`Dns::gethostbyaddr` to `Dns::get_host_by_name`/`Dns::get_host_by_address`
@@ -50,10 +55,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.2.0] - 2020-12-02
 
 ### Added
+
 - Added a new `UdpServer` trait with server-specific methods
 - Added a new `TcpServer` trait with server-specific methods
 
 ### Changed
+
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 - Changed the name of `UdpStack` to `UdpClient`
 - Changed name of `TcpStack` to `TcpClient`
@@ -63,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `UdpStack::connect()` to modify an existing socket
 
 ### Removed
+
 - Removed `Mode` enum, implementations should instead use `nb::WouldBlock`
 
 ## [0.1.0] - 2020-08-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Diego Barrios Romero <eldruin@gmail.com>",
     "Ryan Summers <ryan.summers@vertigo-designs.com>",
 ]
-edition = "2018"
+edition = "2021"
 description = "A Network Abstraction Layer (NAL) for Embedded Systems"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-embedded-community/embedded-nal"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These issues / PRs will be labeled as `proposal`s in the issue tracker.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.53.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60.0 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![feature(async_fn_in_trait, impl_trait_projections)]
-#![allow(incomplete_features)]
+#![allow(stable_features, unknown_lints, async_fn_in_trait)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]


### PR DESCRIPTION
dep `byteorder` increased MSRV to 1.60. Also, some deps are already using edition 2021, making CI fail. Let's just
bump the MSRV a bit.

- async: fix AFIT warnings on latest nightlies.
- Switch to Edition 2021, bump MSRV.
