### PR TITLE
Remove unneeded `where Self: 'a` bound in `TcpClient::connect`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [staging, trying, master]
   pull_request:
 
 name: Continuous integration
@@ -14,11 +14,12 @@ jobs:
         rust: [stable]
 
         # The default target we're compiling on and for
-        TARGET: [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
+        TARGET:
+          [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 
         include:
           # Test MSRV
-          - rust: 1.53.0
+          - rust: 1.60.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -42,7 +43,8 @@ jobs:
     strategy:
       matrix:
         rust: [nightly-2022-11-22]
-        TARGET: [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
+        TARGET:
+          [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [nightly-2022-11-22]
+        rust: [nightly-2023-11-01]
         TARGET:
           [x86_64-unknown-linux-gnu, thumbv6m-none-eabi, thumbv7m-none-eabi]
 

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [staging, trying, master]
   pull_request:
 
 name: Code formatting check
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2022-11-22
+          toolchain: nightly-2023-11-01
           components: rustfmt
       - run: cargo fmt --all -- --check
         working-directory: embedded-nal-async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Bump MSRV to 1.60.0 (required for Edition 2021)
 - Switch to Edition 2021
+- [breaking] `Dns::get_host_by_address` now uses `&mut [u8]` instead of `heapless::String`.
 
 ## [0.7.0] - 2023-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Bump MSRV to 1.60.0 (required for Edition 2021)
+- Switch to Edition 2021
+
 ## [0.7.0] - 2023-06-21
 
-* Add blanket impls of all the traits for mutable references.
+- Add blanket impls of all the traits for mutable references.
 - Bump dependency version of `no-std-net` to `v0.6`.
 - Bump MSRV to 1.53.0 due to `no-std-net`'s use of or-patterns.
 - Added support for `core::net` with the `ip_in_core` feature.
@@ -30,18 +33,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0] - 2021-03-05
 
 ### Changed
+
 - Changed [`Dns`](./src/dns.rs) methods to return `nb::Result<..>` to allow non-blocking implementations.
 - Bump dependency version of `heapless` to `v0.6.1` to address security issue of sub-dependency.
 - Bump dependency version of `no-std-net` to `v0.5`.
 - Bump MSRV to 1.46.0 to get `const-fn` for `no-std-net`.
 
-
 ## [0.3.0] - 2021-02-15
 
 ### Added
+
 - New optional struct [`SharedNal`](./src/stack/share.rs) that can share a single underlying implementation among several users within a thread.
 
 ### Changed
+
 - Changed the names of `UdpClient`/`TcpClient` to `UdpClientStack`/`TcpClientStack`
 - Changed the names of `UdpServer`/`TcpServer` to `UdpFullStack`/`TcpFullStack`
 - Changed the method names `Dns::gethostbyname`/`Dns::gethostbyaddr` to `Dns::get_host_by_name`/`Dns::get_host_by_address`
@@ -50,10 +55,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.2.0] - 2020-12-02
 
 ### Added
+
 - Added a new `UdpServer` trait with server-specific methods
 - Added a new `TcpServer` trait with server-specific methods
 
 ### Changed
+
 - Changed the `UdpStack::receive` method to return the packet sender address, along with the packet length
 - Changed the name of `UdpStack` to `UdpClient`
 - Changed name of `TcpStack` to `TcpClient`
@@ -63,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `UdpStack::connect()` to modify an existing socket
 
 ### Removed
+
 - Removed `Mode` enum, implementations should instead use `nb::WouldBlock`
 
 ## [0.1.0] - 2020-08-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Diego Barrios Romero <eldruin@gmail.com>",
     "Ryan Summers <ryan.summers@vertigo-designs.com>",
 ]
-edition = "2018"
+edition = "2021"
 description = "A Network Abstraction Layer (NAL) for Embedded Systems"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-embedded-community/embedded-nal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ ip_in_core = []
 [dependencies]
 nb = "1"
 no-std-net = { version = "0.6", optional = true }
-heapless = "^0.7"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These issues / PRs will be labeled as `proposal`s in the issue tracker.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.53.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60.0 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [breaking] `Dns::get_host_by_address` now uses `&mut [u8]` instead of `heapless::String`.
+- [breaking] Remove unneeded `where Self: 'a` bound in `TcpClient::connect`.
 
 ## [0.6.0] - 2023-10-03
 

--- a/embedded-nal-async/CHANGELOG.md
+++ b/embedded-nal-async/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No unreleased changes yet.
+- [breaking] `Dns::get_host_by_address` now uses `&mut [u8]` instead of `heapless::String`.
 
 ## [0.6.0] - 2023-10-03
 

--- a/embedded-nal-async/Cargo.toml
+++ b/embedded-nal-async/Cargo.toml
@@ -16,6 +16,5 @@ ip_in_core = []
 
 [dependencies]
 no-std-net = "0.6"
-heapless = "^0.7"
 embedded-nal = { version = "0.7.0", path = "../" }
 embedded-io-async = { version = "0.6.0" }

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -9,9 +9,6 @@
 
 mod dns;
 mod stack;
-// Needed by embedded-nal trait implementers who build get_host_by_address results, or by trait
-// users who pass the results on.
-pub use heapless;
 
 #[cfg(feature = "ip_in_core")]
 pub use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![feature(async_fn_in_trait, impl_trait_projections)]
-#![allow(incomplete_features)]
+#![allow(stable_features, unknown_lints, async_fn_in_trait)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]

--- a/embedded-nal-async/src/stack/tcp.rs
+++ b/embedded-nal-async/src/stack/tcp.rs
@@ -17,10 +17,8 @@ pub trait TcpConnect {
 	/// Connect to the given remote host and port.
 	///
 	/// Returns `Ok` if the connection was successful.
-	async fn connect<'a>(&'a self, remote: SocketAddr) -> Result<Self::Connection<'a>, Self::Error>
-	// This bound is required due to an AFIT limitaton: https://github.com/rust-lang/rust/issues/104908
-	where
-		Self: 'a;
+	async fn connect<'a>(&'a self, remote: SocketAddr)
+		-> Result<Self::Connection<'a>, Self::Error>;
 }
 
 impl<T: TcpConnect> TcpConnect for &T {
@@ -28,10 +26,10 @@ impl<T: TcpConnect> TcpConnect for &T {
 
 	type Connection<'a> = T::Connection<'a> where Self: 'a;
 
-	async fn connect<'a>(&'a self, remote: SocketAddr) -> Result<Self::Connection<'a>, Self::Error>
-	where
-		Self: 'a,
-	{
+	async fn connect<'a>(
+		&'a self,
+		remote: SocketAddr,
+	) -> Result<Self::Connection<'a>, Self::Error> {
 		T::connect(self, remote).await
 	}
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,5 +1,4 @@
 use crate::IpAddr;
-use heapless::String;
 
 /// This is the host address type to be returned by `gethostbyname`.
 ///
@@ -37,13 +36,18 @@ pub trait Dns {
 		addr_type: AddrType,
 	) -> nb::Result<IpAddr, Self::Error>;
 
-	/// Resolve the hostname of a host, given its ip address
+	/// Resolve the hostname of a host, given its ip address.
+	///
+	/// The hostname is stored at the beginning of `result`, the length is returned.
+	///
+	/// If the buffer is too small to hold the domain name, an error should be returned.
 	///
 	/// **Note**: A fully qualified domain name (FQDN), has a maximum length of
-	/// 255 bytes [`rfc1035`]
+	/// 255 bytes according to [`rfc1035`]. Therefore, you can pass a 255-byte long
+	/// buffer to guarantee it'll always be large enough.
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error>;
+	fn get_host_by_address(&self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error>;
 }
 
 impl<T: Dns> Dns for &mut T {
@@ -57,7 +61,7 @@ impl<T: Dns> Dns for &mut T {
 		T::get_host_by_name(self, hostname, addr_type)
 	}
 
-	fn get_host_by_address(&mut self, addr: IpAddr) -> nb::Result<String<256>, Self::Error> {
-		T::get_host_by_address(self, addr)
+	fn get_host_by_address(&self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error> {
+		T::get_host_by_address(self, addr, result)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@ mod dns;
 mod stack;
 
 pub use nb;
-// Needed by embedded-nal trait implementers who build get_host_by_address results, or by trait
-// users who pass the results on.
-pub use heapless;
 
 #[cfg(not(any(feature = "ip_in_core", feature = "no-std-net")))]
 compile_error!("You must select the ip_in_core feature or the no-std-net feature");


### PR DESCRIPTION
depends on #93.

The limitation mentioned in the code is gone in nightly (since Dec 2022!)