### PR TITLE
Use `feature()` on nightly toolchains only.

### DIFF
--- a/embedded-nal-async/build.rs
+++ b/embedded-nal-async/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::ffi::OsString;
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-changed=build.rs");
+
+	let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+
+	let output = Command::new(rustc)
+		.arg("--version")
+		.output()
+		.expect("failed to run `rustc --version`");
+
+	if String::from_utf8_lossy(&output.stdout).contains("nightly") {
+		println!("cargo:rustc-cfg=nightly");
+	}
+}

--- a/embedded-nal-async/src/lib.rs
+++ b/embedded-nal-async/src/lib.rs
@@ -1,8 +1,9 @@
 //! # embedded-nal-async - An async Network Abstraction Layer for Embedded Systems
 
 #![no_std]
-#![feature(async_fn_in_trait, impl_trait_projections)]
-#![allow(stable_features, unknown_lints, async_fn_in_trait)]
+#![cfg_attr(nightly, allow(stable_features, unknown_lints))]
+#![cfg_attr(nightly, feature(async_fn_in_trait, impl_trait_projections))]
+#![allow(async_fn_in_trait)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]


### PR DESCRIPTION
`feature()` is only allowed on Nightly, it's completely disallowed on stable and beta
even for already-stabilized features. So, we autodetect whether the user is using nightly
and conditionally use `feature()`. This allows the crates to Just Work on current 1.75 beta
and will also Just Work when 1.75 stable is out.

Keeping `feature()` is desirable to keep support for:

- Espressif's xtensa rustc fork. (they build from the stable branch but enable use of `feature()`, so latest xtensa rustc still requires `feature()`)
- Users of older nightlies

Once xtensa rust 1.75 is out, we can remove this (upstream nightlies that require `feature()` will be quite old by then, so dropping support for them should be OK).

I decided to not use already-made crates like `rustversion` to do this because they're quite big and do way more than what we need, so I felt badd adding another dep. The code is inspired from `rustversion`'s build.rs.
