### PR TITLE
Change blocking Dns::get_host_by_address back to mutable self

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -47,7 +47,11 @@ pub trait Dns {
 	/// buffer to guarantee it'll always be large enough.
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&mut self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error>;
+	fn get_host_by_address(
+		&mut self,
+		addr: IpAddr,
+		result: &mut [u8],
+	) -> nb::Result<usize, Self::Error>;
 }
 
 impl<T: Dns> Dns for &mut T {
@@ -61,7 +65,11 @@ impl<T: Dns> Dns for &mut T {
 		T::get_host_by_name(self, hostname, addr_type)
 	}
 
-	fn get_host_by_address(&mut self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error> {
+	fn get_host_by_address(
+		&mut self,
+		addr: IpAddr,
+		result: &mut [u8],
+	) -> nb::Result<usize, Self::Error> {
 		T::get_host_by_address(self, addr, result)
 	}
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -47,7 +47,7 @@ pub trait Dns {
 	/// buffer to guarantee it'll always be large enough.
 	///
 	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-	fn get_host_by_address(&self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error>;
+	fn get_host_by_address(&mut self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error>;
 }
 
 impl<T: Dns> Dns for &mut T {
@@ -61,7 +61,7 @@ impl<T: Dns> Dns for &mut T {
 		T::get_host_by_name(self, hostname, addr_type)
 	}
 
-	fn get_host_by_address(&self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error> {
+	fn get_host_by_address(&mut self, addr: IpAddr, result: &mut [u8]) -> Result<usize, Self::Error> {
 		T::get_host_by_address(self, addr, result)
 	}
 }


### PR DESCRIPTION
This aligns the signature of the blocking Dns trait with get_host_by_name, by re-adding the `&mut self` and `nb::Error` result type.

It used to be this way, but it seems like https://github.com/rust-embedded-community/embedded-nal/pull/93# was a bit too fast on copying over the async api.

Ping @Dirbaio 